### PR TITLE
Substituted MCR base image in Dockerfiles

### DIFF
--- a/AzureIoTEdgeFunctions/HumidityFilterFunction/Docker/linux-x64/Dockerfile
+++ b/AzureIoTEdgeFunctions/HumidityFilterFunction/Docker/linux-x64/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/azureiotedge-functions-binding:1.0-preview
+FROM mcr.microsoft.com/azureiotedge-functions-binding:1.0
 
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot
 

--- a/AzureIoTEdgeFunctions/HumidityFilterFunction/Docker/windows-nano/Dockerfile
+++ b/AzureIoTEdgeFunctions/HumidityFilterFunction/Docker/windows-nano/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/azureiotedge-functions-binding:1.0-preview
+FROM mcr.microsoft.com/azureiotedge-functions-binding:1.0
 
 ENV AzureWebJobsScriptRoot=c:\\approot
 

--- a/AzureIoTEdgeFunctions/TemperatureFilterFunction/Docker/linux-x64/Dockerfile
+++ b/AzureIoTEdgeFunctions/TemperatureFilterFunction/Docker/linux-x64/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/azureiotedge-functions-binding:1.0-preview
+FROM mcr.microsoft.com/azureiotedge-functions-binding:1.0
 
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot
 

--- a/AzureIoTEdgeFunctions/TemperatureFilterFunction/Docker/windows-nano/Dockerfile
+++ b/AzureIoTEdgeFunctions/TemperatureFilterFunction/Docker/windows-nano/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/azureiotedge-functions-binding:1.0-preview
+FROM mcr.microsoft.com/azureiotedge-functions-binding:1.0
 
 ENV AzureWebJobsScriptRoot=c:\\approot
 


### PR DESCRIPTION
## Purpose
In Dockerfiles, substitute base image from mcr.microsoft.com instead of from Docker Hub. Current Microsoft guidance is to use MCR image where available for any official Microsoft image. If questions, please contact danlep.
## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[x ] Yes (potentially) - recommend retesting
[ ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[x ] Other... Please describe: base image update in Dockerfiles
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->